### PR TITLE
Correct the relative Url to an Absolute Url in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ If you want to report bugs please open an issue with details like:
 * what were you trying to do?
 * which browser you were on?
 
-### [Join our server](discord.gg/twt)
+### [Join our server](https://discord.gg/twt)


### PR DESCRIPTION
This was causing a 404 (Not Found) error on GitHub on pressing the old link
<img width="1302" alt="Screen Shot 2020-11-16 at 2 34 58 PM" src="https://user-images.githubusercontent.com/62844691/99257267-c567e000-283c-11eb-9756-81d7ce00d44c.png">
I corrected that and it now redirects to the right (not broken link)
<img width="1440" alt="Screen Shot 2020-11-16 at 2 35 36 PM" src="https://user-images.githubusercontent.com/62844691/99257316-d9134680-283c-11eb-84e8-0c6f1a5990bf.png">

