### PR TITLE
Removed `display: none` from the media query for `.base-timer--svg`

### DIFF
--- a/TWT/static/css/index.css
+++ b/TWT/static/css/index.css
@@ -149,10 +149,6 @@
     grid-gap: 1rem;
   }
 
-  .base-timer__svg{
-    display: none;
-  }
-
   .base-timer__label{
     position: initial;
   }


### PR DESCRIPTION
⚠Not Tested